### PR TITLE
use CLI flags for LightGBM GPU install

### DIFF
--- a/scripts/install_lightgbm.sh
+++ b/scripts/install_lightgbm.sh
@@ -16,9 +16,8 @@ apt install -y ocl-icd-opencl-dev libboost-dev libboost-system-dev libboost-file
 # clone LightGBM
 git clone --recursive https://github.com/Microsoft/LightGBM
 
-# WARN: set use_gpu to TRUE in R-package/src/install.libs.R 
 cd LightGBM
-Rscript build_r.R
+Rscript build_r.R --use-gpu
 cd ~
 
 


### PR DESCRIPTION
👋 hello from Chicago.

I'm one of the LightGBM maintainers.

`{lightgbm}`'s CMake-based build (the non-CRAN one) no longer requires manually changing variables in `R-package/install.libs.R`. As of https://github.com/microsoft/LightGBM/pull/3574, you can pass flags like `Rscript build_r.R --use-gpu`.

This PR proposes changing the scripts in this project to use that strategy, since it's less likely to be broken by future changes to `{lightgbm}`.

I'm making PRs like there wherever I find people manually changing `install.libs.R`, , to raise awareness of this new option.